### PR TITLE
【Fixed】Feature/issues#3

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -21,6 +21,10 @@ class AgendasController < ApplicationController
     end
   end
 
+  def destroy
+    
+  end
+
   private
 
   def set_agenda

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -22,7 +22,11 @@ class AgendasController < ApplicationController
   end
 
   def destroy
-    
+    binding.irb
+    @agenda = Agenda.find(params[:id])
+    @agenda.destroy
+    redirect_to dashboard_path
+    binding.irb
   end
 
   private

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -22,11 +22,13 @@ class AgendasController < ApplicationController
   end
 
   def destroy
-    binding.irb
+    byebug
     @agenda = Agenda.find(params[:id])
-    @agenda.destroy
+    if current_user == set_agenda.team.owner || current_user == @agenda.user
+      byebug
+      @agenda.destroy
+    end
     redirect_to dashboard_path
-    binding.irb
   end
 
   private

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -22,11 +22,12 @@ class AgendasController < ApplicationController
   end
 
   def destroy
-    byebug
     @agenda = Agenda.find(params[:id])
     if current_user == set_agenda.team.owner || current_user == @agenda.user
-      byebug
       @agenda.destroy
+      @agenda.team.users.each do |user|
+        AgendaMailer.agenda_delete_mail(user.email, @agenda).deliver
+      end
     end
     redirect_to dashboard_path
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
 
   def check_user_from_team_show
     unless current_user == @team.owner
-      flash[:notice] = "オーナー以外のユーザーはチーム編集、自分以外のメンバーの削除はできません"
+      flash[:notice] = "オーナー以外のユーザーは削除できません"
       render :show
     end
   end

--- a/app/mailers/agenda_mailer.rb
+++ b/app/mailers/agenda_mailer.rb
@@ -1,0 +1,9 @@
+class AgendaMailer < ApplicationMailer
+  default from: 'from@example.com'
+
+  def agenda_delete_mail(email, agenda)
+    @email = email
+    @agenda = agenda
+    mail to: @email
+  end
+end

--- a/app/views/agenda_mailer/agenda_delete_mail.html.erb
+++ b/app/views/agenda_mailer/agenda_delete_mail.html.erb
@@ -1,0 +1,3 @@
+<h1>agenda title:<%= @agenda.title %>を削除しました</h1>
+
+<h4>email: <%= @email %></h4>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -34,6 +34,7 @@
               <i class="fa fa-circle-o nav-icon"></i>
               <p>
                 <%= agenda.title %>
+                <object><button><%= link_to "削除",teams_path, class:"text-danger" %></button></object>
                 <i class="right fa fa-angle-left"></i>
               </p>
             </a>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -38,7 +38,9 @@
                   <i class="right fa fa-angle-left"></i>
                 </p>
               </a>
-              <span><button><%= link_to "削除",agenda_path(agenda.id), method: :delete, class:"text-danger" %></button></span>
+              <% if current_user == agenda.team.owner || current_user == agenda.user %>
+                <span><button><%= link_to "削除",agenda_path(agenda.id), method: :delete, class:"text-danger" %></button></span>
+              <% end %>
             </div>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -30,14 +30,16 @@
       <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
         <% @working_team.agendas.each do |agenda| %>
           <li class="nav-item has-treeview menu-open">
-            <a href="#" class="nav-link">
-              <i class="fa fa-circle-o nav-icon"></i>
-              <p>
-                <%= agenda.title %>
-                <object><button><%= link_to "削除",teams_path, class:"text-danger" %></button></object>
-                <i class="right fa fa-angle-left"></i>
-              </p>
-            </a>
+            <div class = "form-inline">
+              <a href="#" class="nav-link">
+                <i class="fa fa-circle-o nav-icon"></i>
+                <p>
+                  <%= agenda.title %>
+                  <i class="right fa fa-angle-left"></i>
+                </p>
+              </a>
+              <span><button><%= link_to "削除",agenda_path(agenda.id), method: :delete, class:"text-danger" %></button></span>
+            </div>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>
                 <li class="nav-item">

--- a/spec/mailers/agenda_mailer_spec.rb
+++ b/spec/mailers/agenda_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe AgendaMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/agenda_mailer_preview.rb
+++ b/spec/mailers/previews/agenda_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/agenda_mailer
+class AgendaMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
fix #3

- [x] AgendasControllerのdestroyアクションを追加し、そこに機能追加する
- [x] Agendaの名前の右の部分に削除ボタンを作成し、そのボタンを押すとそのAgendaが削除される
- [x] Agendaに紐づいているarticleも一緒に削除される
- [x] Agendaを削除できるのは、そのAgendaの作者もしくはそのAgendaに紐づいているTeamの作者（オーナー）のみ
- [x] Agendaが削除されると、そのAgendaに紐づいているTeamに所属しているユーザー全員に通知メールが飛ぶ
- [x] 情報処理が完了した後はDashBoardに飛ぶ
- [x] その他、アプリケーションの挙動に不審な点やエラーがないこと


ご確認のほどよろしくお願い致します。